### PR TITLE
Fix User builder

### DIFF
--- a/src/Sidecar.php
+++ b/src/Sidecar.php
@@ -6,7 +6,7 @@ class Sidecar
 {
     public static string $userModel = \App\Models\User::class; // @phpstan-ignore-line
 
-    public static mixed $userBuilder;
+    public static mixed $userBuilder = null;
 
     /**
      * @var array<string, string>
@@ -33,6 +33,6 @@ class Sidecar
 
     public static function getUserQueryBuilder(): mixed
     {
-        return self::$userBuilder;
+        return self::$userBuilder ?? self::$userModel::query();
     }
 }

--- a/tests/Feature/SetSidecarTokenControllerTest.php
+++ b/tests/Feature/SetSidecarTokenControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\{Config};
+use Illuminate\Support\Str;
 
 use function Pest\Laravel\post;
 


### PR DESCRIPTION
Fix: Typed static property EliteDevSquad\\SidecarLaravel\\Sidecar::$userBuilder must not be accessed before initialization