### PR TITLE
Fix fake clock

### DIFF
--- a/src/Http/Controllers/ExecuteCommandController.php
+++ b/src/Http/Controllers/ExecuteCommandController.php
@@ -2,28 +2,26 @@
 
 namespace EliteDevSquad\SidecarLaravel\Http\Controllers;
 
-use DateTimeInterface;
 use EliteDevSquad\SidecarLaravel\Http\Requests\ExecuteCommandRequest;
+use EliteDevSquad\SidecarLaravel\Traits\WithFakeClock;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Throwable;
 
 readonly class ExecuteCommandController
 {
+    use WithFakeClock;
+
     public function __invoke(ExecuteCommandRequest $request): JsonResponse
     {
         /**
          * @var array{
          *     command: string,
-         *     clock?: string|int|float|DateTimeInterface|null
          * } $data
          */
         $data = $request->validated();
 
-        if (isset($data['clock']) && config('devsquad-sidecar.fake_clock_enabled')) {
-            Carbon::setTestNow($request->date('clock'));
-        }
+        $this->setFakeClock();
 
         try {
             /** @var string $command */

--- a/src/Http/Controllers/ExecuteFakeClockController.php
+++ b/src/Http/Controllers/ExecuteFakeClockController.php
@@ -27,7 +27,7 @@ class ExecuteFakeClockController
 
         Carbon::setTestNow();
 
-        session()->forget('sidecar_fake_clock');
+        session(['sidecar_fake_clock' => null]);
 
         return response()->json(['output' => 'Fake clock reset to real time']);
     }

--- a/src/Http/Controllers/ExecuteTinkerController.php
+++ b/src/Http/Controllers/ExecuteTinkerController.php
@@ -2,29 +2,26 @@
 
 namespace EliteDevSquad\SidecarLaravel\Http\Controllers;
 
-use Carbon\{Month, WeekDay};
-use DateTimeInterface;
 use EliteDevSquad\SidecarLaravel\Http\Requests\ExecuteTinkerRequest;
+use EliteDevSquad\SidecarLaravel\Traits\WithFakeClock;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Throwable;
 
 readonly class ExecuteTinkerController
 {
+    use WithFakeClock;
+
     public function __invoke(ExecuteTinkerRequest $request): JsonResponse
     {
         /**
          * @var array{
-         *     code: string,
-         *     clock?: Month|WeekDay|DateTimeInterface|float|int|string|null
+         *     code: string
          * } $data
          */
         $data = $request->validated();
 
-        if (isset($data['clock']) && config('devsquad-sidecar.fake_clock_enabled')) {
-            Carbon::setTestNow($request->date('clock'));
-        }
+        $this->setFakeClock();
 
         try {
             Artisan::call('tinker', ['--execute' => $data['code']]);

--- a/src/Http/Middleware/FakeClockMiddleware.php
+++ b/src/Http/Middleware/FakeClockMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace EliteDevSquad\SidecarLaravel\Http\Middleware;
+
+use Closure;
+use DateTimeInterface;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+class FakeClockMiddleware
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if (session()->has('sidecar_fake_clock')) {
+            Log::debug('Fake clock activated by DevSquad Sidecar');
+
+            /** @var Closure|DateTimeInterface|string|false|null $clock */
+            $clock = session('sidecar_fake_clock');
+            Carbon::setTestNow($clock);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Requests/ExecuteCommandRequest.php
+++ b/src/Http/Requests/ExecuteCommandRequest.php
@@ -18,7 +18,6 @@ class ExecuteCommandRequest extends FormRequest
     {
         return [
             'command' => ['string', 'required'],
-            'clock' => ['nullable', 'date', 'date_format:Y-m-d H:i:s'],
         ];
     }
 }

--- a/src/Http/Requests/ExecuteTinkerRequest.php
+++ b/src/Http/Requests/ExecuteTinkerRequest.php
@@ -18,7 +18,6 @@ class ExecuteTinkerRequest extends FormRequest
     {
         return [
             'code' => ['required', 'string'],
-            'clock' => ['nullable', 'date', 'string', 'date_format:Y-m-d H:i:s'],
         ];
     }
 

--- a/src/Providers/SidecarServiceProvider.php
+++ b/src/Providers/SidecarServiceProvider.php
@@ -5,7 +5,7 @@ namespace EliteDevSquad\SidecarLaravel\Providers;
 use EliteDevSquad\SidecarLaravel\Http\Middleware\SidecarMiddleware;
 use EliteDevSquad\SidecarLaravel\Sidecar;
 use Illuminate\Routing\Router;
-use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Illuminate\Support\{Carbon, Facades\Log, ServiceProvider as BaseServiceProvider};
 
 class SidecarServiceProvider extends BaseServiceProvider
 {
@@ -23,6 +23,11 @@ class SidecarServiceProvider extends BaseServiceProvider
         );
 
         $router->aliasMiddleware('devsquad-sidecar-auth', SidecarMiddleware::class);
+
+        if (session()->has('sidecar_fake_clock')) {
+            Log::debug('Fake clock activated by devsquad sidecar');
+            Carbon::setTestNow(session('sidecar_fake_clock'));
+        }
     }
 
     public function register(): void

--- a/src/Providers/SidecarServiceProvider.php
+++ b/src/Providers/SidecarServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace EliteDevSquad\SidecarLaravel\Providers;
 
-use DateTimeInterface;
-use EliteDevSquad\SidecarLaravel\Http\Middleware\SidecarMiddleware;
+use EliteDevSquad\SidecarLaravel\Http\Middleware\{FakeClockMiddleware, SidecarMiddleware};
 use EliteDevSquad\SidecarLaravel\Sidecar;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
-use Illuminate\Support\{Carbon, Facades\Log, ServiceProvider as BaseServiceProvider};
+use Illuminate\Support\{ServiceProvider as BaseServiceProvider};
 
 class SidecarServiceProvider extends BaseServiceProvider
 {
@@ -25,14 +25,8 @@ class SidecarServiceProvider extends BaseServiceProvider
 
         $router->aliasMiddleware('devsquad-sidecar-auth', SidecarMiddleware::class);
 
-        if (session()->has('sidecar_fake_clock')) {
-            Log::debug('Fake clock activated by devsquad sidecar');
-
-            /** @var \Closure|DateTimeInterface|string|false|null $clock */
-            $clock = session('sidecar_fake_clock');
-
-            Carbon::setTestNow($clock);
-        }
+        $kernel = $this->app->make(Kernel::class);
+        $kernel->appendMiddlewareToGroup('web', FakeClockMiddleware::class);
     }
 
     public function register(): void

--- a/src/Providers/SidecarServiceProvider.php
+++ b/src/Providers/SidecarServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace EliteDevSquad\SidecarLaravel\Providers;
 
+use DateTimeInterface;
 use EliteDevSquad\SidecarLaravel\Http\Middleware\SidecarMiddleware;
 use EliteDevSquad\SidecarLaravel\Sidecar;
 use Illuminate\Routing\Router;
@@ -26,7 +27,11 @@ class SidecarServiceProvider extends BaseServiceProvider
 
         if (session()->has('sidecar_fake_clock')) {
             Log::debug('Fake clock activated by devsquad sidecar');
-            Carbon::setTestNow(session('sidecar_fake_clock'));
+
+            /** @var \Closure|DateTimeInterface|string|false|null $clock */
+            $clock = session('sidecar_fake_clock');
+
+            Carbon::setTestNow($clock);
         }
     }
 

--- a/src/Traits/WithFakeClock.php
+++ b/src/Traits/WithFakeClock.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EliteDevSquad\SidecarLaravel\Traits;
+
+use Closure;
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+
+trait WithFakeClock
+{
+    public function setFakeClock(): void
+    {
+        $hasFakeClock = session()->has('sidecar_fake_clock') && config('devsquad-sidecar.fake_clock_enabled');
+
+        if (! $hasFakeClock) {
+            return;
+        }
+
+        /** @var Closure|DateTimeInterface|string|false|null $clock */
+        $clock = session('sidecar_fake_clock');
+        Carbon::setTestNow($clock);
+    }
+}

--- a/tests/Feature/ExecuteCommandControllerTest.php
+++ b/tests/Feature/ExecuteCommandControllerTest.php
@@ -19,9 +19,10 @@ it('executes a valid artisan command', function () {
 it('change clock when clock input is provided', function () {
     $newTime = now()->addDays(2)->toDateTimeString();
 
+    session(['sidecar_fake_clock' => $newTime]);
+
     postJson('__devsquad-sidecar/execute-command', [
         'command' => 'view:clear',
-        'clock' => $newTime,
     ])
         ->assertOk()
         ->assertContent('{"output":"\n   INFO  Compiled views cleared successfully.  \n\n"}');

--- a/tests/Feature/ExecuteTinkerControllerTest.php
+++ b/tests/Feature/ExecuteTinkerControllerTest.php
@@ -22,9 +22,10 @@ it('handles exception when executing tinker code', function () {
 it('change clock when clock input is provided', function () {
     $newTime = now()->addDays(2)->toDateTimeString();
 
+    session(['sidecar_fake_clock' => $newTime]);
+
     postJson('__devsquad-sidecar/execute-tinker', [
         'code' => base64_encode('now()'),
-        'clock' => $newTime,
     ])
         ->assertOk();
 


### PR DESCRIPTION
This pull request refactors how the "fake clock" feature is handled across the application, moving from passing the clock value via request parameters to managing it through session state and middleware. The main changes include introducing a dedicated middleware for fake clock handling, updating controllers to use a trait for clock setup, and removing clock-related validation from request objects.

**Fake clock feature refactor:**

* Added `FakeClockMiddleware` (`src/Http/Middleware/FakeClockMiddleware.php`) to automatically set the fake clock from the session for all web requests, centralizing clock management.
* Updated `SidecarServiceProvider` (`src/Providers/SidecarServiceProvider.php`) to register `FakeClockMiddleware` in the web middleware group, ensuring the fake clock is consistently applied.
* Introduced `WithFakeClock` trait (`src/Traits/WithFakeClock.php`) and updated `ExecuteCommandController` and `ExecuteTinkerController` to use it for setting the fake clock, replacing previous inline logic. [[1]](diffhunk://#diff-8e9ed693602bf6f1a237d61f8b61058d6d1e7b15c3165b4404bd0c58f1efe4d4R1-R23) [[2]](diffhunk://#diff-5eae3d7d6f49d13a0ec08f17e337e6f62d10200f8d91a9c648e0dca1b64713b0L5-R24) [[3]](diffhunk://#diff-bfeff377862f2d69470b3201ab468c015a8d0ca99f02712ed19cecf940512b9eL5-R24)

**Request validation and session usage changes:**

* Removed the `clock` field and its validation from `ExecuteCommandRequest` and `ExecuteTinkerRequest`, reflecting the shift to session-based clock management. [[1]](diffhunk://#diff-8c6845fbabce1e6970fa007230e29472727212b22162f14c4183c3b02d0fe1e9L21) [[2]](diffhunk://#diff-8d5e65127e89045009e86044a0cac7d9839ffe4517e148ba0358986a7307e10fL21)
* Updated tests to set the fake clock via session instead of request input, aligning with the new approach. [[1]](diffhunk://#diff-ce7c36ef03211d920694819e6ae2856e20902c1c8c44d906a81ebb8b3333bb31R22-L24) [[2]](diffhunk://#diff-e47f4f0200ca5b6d0971050ad22418465ee8e6de8cd983c6da9cf8cdb1c404cdR25-L27)

**Controller logic update:**

* Changed `ExecuteFakeClockController` to reset the fake clock by setting the session value to `null` instead of forgetting the session key, ensuring consistent session state.