### PR TITLE
Ensure the FakeClockMiddleware is disabled in production

### DIFF
--- a/src/Http/Middleware/FakeClockMiddleware.php
+++ b/src/Http/Middleware/FakeClockMiddleware.php
@@ -12,6 +12,10 @@ class FakeClockMiddleware
 {
     public function handle(Request $request, Closure $next): mixed
     {
+        if (app()->isProduction()) {
+            return $next($request);
+        }
+
         if (session()->has('sidecar_fake_clock')) {
             Log::debug('Fake clock activated by DevSquad Sidecar');
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `FakeClockMiddleware` to ensure that fake clock functionality is only activated in non-production environments.

* Middleware logic: Added a check to bypass the fake clock functionality when the application is running in production, ensuring that the middleware only activates the fake clock in development or staging environments.