### PR TITLE
Add console log display control and refresh event listener

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -2,6 +2,7 @@ export class Sidecar {
     constructor() {
         this.csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content");
         this.init();
+        this.consoleShown = false;
     }
 
     async init() {
@@ -54,11 +55,14 @@ export class Sidecar {
             return;
         }
 
-        console.log(
-            `\n%cDevSquad Sidecar Enabled\n%cProject: ${data.project_name}`,
-            "color:#28ef00;font-size:1em;",
-            "color:#aaa;font-size:0.9em;"
-        );
+        if (!this.consoleShown) {
+            console.log(
+                `\n%cDevSquad Sidecar Enabled\n%cProject: ${data.project_name}`,
+                "color:#28ef00;font-size:1em;",
+                "color:#aaa;font-size:0.9em;"
+            );
+            this.consoleShown = true;
+        }
 
         this.dispatch("sidecar:to:extension:data", data);
     }
@@ -75,12 +79,17 @@ export class Sidecar {
             } else {
                 localStorage.setItem("sidecar_authenticated", "true");
                 alert("🎉 API token set successfully!");
+                window.location.reload();
             }
         });
 
         window.addEventListener("sidecar:to:page:selectUser", ({ detail }) => {
             this.handleUserLogin(detail.id);
         });
+
+        window.addEventListener("sidecar:to:page::refresh", async () => {
+            await this.fetchInitialData();
+        })
 
         const commandEndpoints = {
             "sidecar:to:page:executeCommand": ["/__devsquad-sidecar/execute-command", "sidecar:to:extension:commandOutput"],


### PR DESCRIPTION
This pull request introduces improvements to the `Sidecar` class in `resources/js/index.js`, focusing on better user feedback and reliability of the extension's initialization and authentication flow. The main changes ensure that console messages are only shown once, the page reloads after successful API token setup, and a new event allows refreshing initial data.

**User experience and feedback improvements:**

* Added a check to display the "DevSquad Sidecar Enabled" console message only once per session, preventing duplicate logs. [[1]](diffhunk://#diff-8fc920e6bb1cf9f8ef97c22a1a7f1296fa5abcba08cec69ca257939c0d84ef78R5) [[2]](diffhunk://#diff-8fc920e6bb1cf9f8ef97c22a1a7f1296fa5abcba08cec69ca257939c0d84ef78R58-R65)
* Reloads the page automatically after a successful API token setup to ensure the latest authentication state is reflected.

**Event handling and data refresh:**

* Introduced a new `sidecar:to:page::refresh` event listener to allow external triggers to refresh initial data by calling `fetchInitialData`.