### PR TITLE
fix: safely retrieve user role in SidecarUserResource when role key is missing

### DIFF
--- a/src/Http/Resources/SidecarUserResource.php
+++ b/src/Http/Resources/SidecarUserResource.php
@@ -23,7 +23,7 @@ class SidecarUserResource extends JsonResource
             'id' => data_get($this->resource, $userMap['id']),
             'name' => data_get($this->resource, $userMap['name']),
             'email' => data_get($this->resource, $userMap['email']),
-            'role' => data_get($this->resource, $userMap['role']) ?? 'user',
+            'role' => data_get($this->resource, $userMap['role'] ?? null) ?? 'user',
         ];
     }
 }


### PR DESCRIPTION
This pull request makes a small adjustment to how the `role` attribute is retrieved in the `SidecarUserResource`. The change ensures that if the `role` key is missing from the `$userMap`, the code will not throw an error and will default to `'user'` as intended.

- Improved robustness when retrieving the `role` attribute by handling cases where the `role` key may be missing from `$userMap` in `SidecarUserResource.php`.