### PR TITLE
fix: safely retrieve user role in SidecarUserResource when role key is missing

### DIFF
--- a/src/Http/Resources/SidecarUserResource.php
+++ b/src/Http/Resources/SidecarUserResource.php
@@ -23,7 +23,7 @@ class SidecarUserResource extends JsonResource
             'id' => data_get($this->resource, $userMap['id']),
             'name' => data_get($this->resource, $userMap['name']),
             'email' => data_get($this->resource, $userMap['email']),
-            'role' => data_get($this->resource, $userMap['role'] ?? null) ?? 'user',
+            'role' => data_get($this->resource, $userMap['role'] ?? 'user') ?? 'user',
         ];
     }
 }


### PR DESCRIPTION
This pull request makes a small adjustment to how the default user role is determined in the `SidecarUserResource`. The change ensures that if the `role` mapping is not set, it will default to `'user'` earlier in the data retrieval process, making the logic clearer and more robust.

- Improved default handling for the `role` attribute in the `toArray` method of `SidecarUserResource`, ensuring the default `'user'` role is applied if no mapping is provided.