### PR TITLE
ci: support php 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       matrix:
         php-version: [ 8.5, 8.4, 8.3, 8.2 ]
         laravel-version: [ 12.*, 11.* ]
+        exclude:
+          - php-version: 8.5
+            laravel-version: 11.*
       fail-fast: false
 
     name: PHP:${{ matrix.php-version }} / L:${{ matrix.laravel-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ 8.4, 8.3, 8.2 ]
+        php-version: [ 8.5, 8.4, 8.3, 8.2 ]
         laravel-version: [ 12.*, 11.* ]
       fail-fast: false
 


### PR DESCRIPTION
This pull request updates the PHP version matrix in the GitHub Actions workflow to include the latest PHP release for automated testing.