### PR TITLE
feat: add ClearUserCacheController and route to clear user cache

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -96,6 +96,7 @@ export class Sidecar {
             "sidecar:to:page:executeTinker": ["/__devsquad-sidecar/execute-tinker", "sidecar:to:extension:tinkerOutput"],
             "sidecar:to:page:executeFakeClock": ["/__devsquad-sidecar/execute-fake-clock", "sidecar:to:extension:fakeClockOutput"],
             "sidecar:to:page:executeTinkerOnQueue": ["/__devsquad-sidecar/execute-tinker-on-queue", "sidecar:to:extension:tinkerOutput"],
+            "sidecar:to:page:clearUserCache": ["/__devsquad-sidecar/clear-user-cache", "sidecar:to:extension:clearUserCacheOutput"],
         };
 
         for (const event in commandEndpoints) {

--- a/resources/routes.php
+++ b/resources/routes.php
@@ -1,11 +1,12 @@
 <?php
 
-use EliteDevSquad\SidecarLaravel\Http\Controllers\{ExecuteCommandController, ExecuteTinkerOnQueueController};
-use EliteDevSquad\SidecarLaravel\Http\Controllers\{ExecuteFakeClockController,
+use EliteDevSquad\SidecarLaravel\Http\Controllers\{ClearUserCacheController,
+    ExecuteFakeClockController,
     ExecuteTinkerController,
     GetSidecarDataController,
     LoginAsUserController,
     SetSidecarTokenController};
+use EliteDevSquad\SidecarLaravel\Http\Controllers\{ExecuteCommandController, ExecuteTinkerOnQueueController};
 use Illuminate\Support\Facades\Route;
 
 if (! app()->isProduction()) {
@@ -20,6 +21,7 @@ if (! app()->isProduction()) {
             Route::post('/execute-tinker', ExecuteTinkerController::class);
             Route::post('/execute-fake-clock', ExecuteFakeClockController::class);
             Route::post('/execute-tinker-on-queue', ExecuteTinkerOnQueueController::class);
+            Route::post('/clear-user-cache', ClearUserCacheController::class);
         });
     });
 }

--- a/src/Http/Controllers/ClearUserCacheController.php
+++ b/src/Http/Controllers/ClearUserCacheController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EliteDevSquad\SidecarLaravel\Http\Controllers;
+
+use Illuminate\Http\{JsonResponse, Request};
+use Illuminate\Support\Facades\{Cache};
+use Throwable;
+
+readonly class ClearUserCacheController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        try {
+            Cache::forget('sidecar_users');
+
+            $output = 'User cache cleared successfully.';
+        } catch (Throwable $e) {
+            $output = 'Error executing command: '.$e->getMessage();
+        }
+
+        return response()->json(['output' => $output]);
+    }
+}

--- a/src/Http/Controllers/GetSidecarDataController.php
+++ b/src/Http/Controllers/GetSidecarDataController.php
@@ -53,7 +53,7 @@ class GetSidecarDataController
     {
         $builder = $this->sidecar->getUserQueryBuilder();
 
-        $users = $builder->get(); // @phpstan-ignore-line
+        $users = Cache::rememberForever('sidecar_users', fn () => $builder->get());
 
         return SidecarUserResource::collection($users)->all(); // @phpstan-ignore-line
     }

--- a/src/Http/Controllers/GetSidecarDataController.php
+++ b/src/Http/Controllers/GetSidecarDataController.php
@@ -53,7 +53,7 @@ class GetSidecarDataController
     {
         $builder = $this->sidecar->getUserQueryBuilder();
 
-        $users = Cache::rememberForever('sidecar_users', fn () => $builder->get());
+        $users = Cache::rememberForever('sidecar_users', fn () => $builder->get()); // @phpstan-ignore-line
 
         return SidecarUserResource::collection($users)->all(); // @phpstan-ignore-line
     }


### PR DESCRIPTION
This pull request adds a new backend endpoint and controller to clear the cached user data, and updates the user retrieval logic to utilize persistent caching. These changes improve cache management and allow for manual cache clearing via a new API route.

**User Cache Management Improvements:**

* Added a new `ClearUserCacheController` that provides an endpoint to clear the `sidecar_users` cache key and return a status message.
* Updated the user retrieval logic in `GetSidecarDataController` to use `Cache::rememberForever` for the `sidecar_users` key, ensuring user data is cached persistently.

**API and Route Changes:**

* Registered a new POST route `/clear-user-cache` mapped to the `ClearUserCacheController` for non-production environments.
* Updated route imports in `resources/routes.php` to include `ClearUserCacheController`.

**Frontend Integration:**

* Added a new command mapping in the `Sidecar` class (`resources/js/index.js`) for `"sidecar:to:page:clearUserCache"`, integrating the new backend endpoint with the frontend event system.