### PR TITLE
fix: remove unnecessary initial data fetch in init method

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -6,7 +6,6 @@ export class Sidecar {
     }
 
     async init() {
-        await this.fetchInitialData();
         this.setupEventListeners();
     }
 


### PR DESCRIPTION
This pull request makes a small change to the initialization logic in the `Sidecar` class. The change removes the call to `fetchInitialData()` from the `init()` method, so initial data will no longer be fetched automatically when the sidecar is initialized.