### PR TITLE
fix: update namespace for SideCarExecuteTinkerJob and adjust imports

### DIFF
--- a/src/Http/Controllers/ExecuteTinkerOnQueueController.php
+++ b/src/Http/Controllers/ExecuteTinkerOnQueueController.php
@@ -2,8 +2,8 @@
 
 namespace EliteDevSquad\SidecarLaravel\Http\Controllers;
 
-use EliteDevSquad\SidecarLaravel\Http\Jobs\SideCarExecuteTinkerJob;
 use EliteDevSquad\SidecarLaravel\Http\Requests\ExecuteTinkerRequest;
+use EliteDevSquad\SidecarLaravel\Jobs\SideCarExecuteTinkerJob;
 use EliteDevSquad\SidecarLaravel\Traits\WithFakeClock;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Bus;

--- a/src/Jobs/SideCarExecuteTinkerJob.php
+++ b/src/Jobs/SideCarExecuteTinkerJob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EliteDevSquad\SidecarLaravel\Http\Jobs;
+namespace EliteDevSquad\SidecarLaravel\Jobs;
 
 use Illuminate\Bus\{Batchable, Queueable};
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Feature/ExecuteTinkerOnQueueTest.php
+++ b/tests/Feature/ExecuteTinkerOnQueueTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use EliteDevSquad\SidecarLaravel\Http\Jobs\SideCarExecuteTinkerJob;
+use EliteDevSquad\SidecarLaravel\Jobs\SideCarExecuteTinkerJob;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\{Artisan, Bus, Log, Queue};


### PR DESCRIPTION
This pull request refactors the location and namespace of the `SideCarExecuteTinkerJob` class to improve code organization and maintain consistency across the codebase. The job class has been moved from the `Http/Jobs` directory to the main `Jobs` directory, and all references have been updated accordingly.