### PR TITLE
fix: modify GetSidecarDataController to conditionally fetch users bas…

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -6,6 +6,7 @@ export class Sidecar {
     }
 
     async init() {
+        await this.fetchInitialData(true);
         this.setupEventListeners();
     }
 
@@ -44,8 +45,8 @@ export class Sidecar {
         }
     }
 
-    async fetchInitialData() {
-        const data = await this.request("/__devsquad-sidecar/data");
+    async fetchInitialData(withoutUsers = false) {
+        const data = await this.request("/__devsquad-sidecar/data?without_users=" + (withoutUsers ? "true" : "false"), {});
 
         if (data.error) {
             if (data.error.statusCode === 403) {

--- a/src/Http/Controllers/GetSidecarDataController.php
+++ b/src/Http/Controllers/GetSidecarDataController.php
@@ -13,7 +13,7 @@ class GetSidecarDataController
 
     public function __invoke(Request $request): JsonResponse
     {
-        $initialRequest = $request->get('without_users');
+        $initialRequest = $request->get('without_users') ?? 'false';
 
         /** @var string $defaultConnection */
         $defaultConnection = config('database.default', '');

--- a/src/Http/Controllers/GetSidecarDataController.php
+++ b/src/Http/Controllers/GetSidecarDataController.php
@@ -4,15 +4,17 @@ namespace EliteDevSquad\SidecarLaravel\Http\Controllers;
 
 use EliteDevSquad\SidecarLaravel\Http\Resources\SidecarUserResource;
 use EliteDevSquad\SidecarLaravel\Sidecar;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\{JsonResponse, Request};
 use Illuminate\Support\Facades\{Auth, Cache};
 
 class GetSidecarDataController
 {
     public function __construct(private readonly Sidecar $sidecar) {}
 
-    public function __invoke(): JsonResponse
+    public function __invoke(Request $request): JsonResponse
     {
+        $initialRequest = $request->get('without_users');
+
         /** @var string $defaultConnection */
         $defaultConnection = config('database.default', '');
 
@@ -25,6 +27,8 @@ class GetSidecarDataController
         /** @var string $projectName */
         $projectName = config('app.name', '');
 
+        $users = $initialRequest == 'false' ? $this->getUsers() : [];
+
         return response()->json([
             'enabled' => true,
             'project_name' => $projectName,
@@ -32,7 +36,7 @@ class GetSidecarDataController
             'branch' => $this->getBranch(),
             'database' => $database,
             'environment' => app()->environment(),
-            'users' => $this->getUsers(),
+            'users' => $users,
             'links' => config('devsquad-sidecar.links', []),
             'commands' => config('devsquad-sidecar.commands', []),
             'branch_url' => $branchUrl,


### PR DESCRIPTION
This pull request updates the way initial data is fetched for the Sidecar feature, allowing for improved control over whether user data is included in the response. The main changes involve passing a new query parameter from the frontend to the backend, and updating the backend logic to conditionally include user data based on this parameter.

**Frontend/Backend Data Fetching Coordination:**

* The `Sidecar` class in `resources/js/index.js` now calls `fetchInitialData(true)` during initialization, and the `fetchInitialData` method accepts a `withoutUsers` parameter to request data without user information by appending a `without_users` query parameter to the API call. [[1]](diffhunk://#diff-8fc920e6bb1cf9f8ef97c22a1a7f1296fa5abcba08cec69ca257939c0d84ef78R9) [[2]](diffhunk://#diff-8fc920e6bb1cf9f8ef97c22a1a7f1296fa5abcba08cec69ca257939c0d84ef78L47-R49)

**Backend API Response Logic:**

* The `GetSidecarDataController` in `src/Http/Controllers/GetSidecarDataController.php` now accepts the request object and reads the `without_users` query parameter to determine whether to include user data.
* The controller conditionally sets the `users` field in the API response to an empty array if `without_users` is true, otherwise it includes the full user data.…ed on the request parameter