### PR TITLE
Implement configurable token duration for Sidecar and improve test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ VITE_DS_SIDECAR_ENABLED="${DS_SIDECAR_ENABLED}"
 DS_SIDECAR_TINKER_ENABLED=true
 DS_SIDECAR_LINK_ENVOYER=https://envoyer.io/projects/xxxxxx
 DS_SIDECAR_LINK_MAIL=https://xxx-mail.sbx.devsquad.app
-DS_SIDECAR_AUTH_TOKEN=your-auth-token-here
+DS_SIDECAR_AUTH_TOKEN="your-token"
 DS_SIDECAR_BRANCH_URL=https://bitbucket.org/elitedevsquad/project-here/branches/
 DS_SIDECAR_TINKER_USE_BATCH=true
+DS_SIDECAR_TOKEN_DURATION_IN_MINUTES=129600
 ```
 
 ### 4 — Add CSRF Meta Tag
@@ -48,7 +49,6 @@ In your main layout (resources/views/layouts/app.blade.php), add:
 ```
 
 Reference: https://laravel.com/docs/12.x/csrf#csrf-x-csrf-token
-
 
 ### 5 — User Mapping
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "pestphp/pest": "^4.0|^3.8",
         "pestphp/pest-plugin-laravel": "^4.0|^3.2",
         "orchestra/testbench": "^10.4|^9.4",
-        "laradumps/laradumps": "^4.3",
+        "laradumps/laradumps": "^4.5",
         "larastan/larastan": "^3.0"
     },
     "scripts": {

--- a/resources/config/devsquad-sidecar.php
+++ b/resources/config/devsquad-sidecar.php
@@ -6,6 +6,9 @@ return [
     // Authentication token for secure Sidecar access
     'auth_token' => env('DS_SIDECAR_AUTH_TOKEN', ''),
 
+    // Token expiration time in minutes - default 90 days: 24 * 60 * 90 = 129600
+    'token_duration_in_minutes' => env('DS_SIDECAR_TOKEN_DURATION_IN_MINUTES', 129600),
+
     // Enable or disable Artisan command execution
     'commands_enabled' => env('DS_SIDECAR_COMMANDS_ENABLED', true),
 

--- a/src/Http/Controllers/SetSidecarTokenController.php
+++ b/src/Http/Controllers/SetSidecarTokenController.php
@@ -21,7 +21,9 @@ readonly class SetSidecarTokenController
             return response()->json(status: 403);
         }
 
-        Cookie::queue('sidecar_token', $token, 60 * 24 * 7);
+        $tokenDurationInMinutes = config('devsquad-sidecar.token_duration_in_minutes');
+
+        Cookie::queue('sidecar_token', $token, $tokenDurationInMinutes);
 
         return response()->json([
             'success' => true,

--- a/tests/Feature/ClearUserCacheControllerTest.php
+++ b/tests/Feature/ClearUserCacheControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use EliteDevSquad\SidecarLaravel\Http\Middleware\SidecarMiddleware;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use function Pest\Laravel\post;
+use function Pest\Laravel\withoutMiddleware;
+
+beforeEach(function () {
+    withoutMiddleware(SidecarMiddleware::class);
+});
+
+it('clears user cache successfully', function () {
+    Cache::shouldReceive('forget')
+        ->once()
+        ->with('sidecar_users')
+        ->andReturnTrue();
+
+    post('__devsquad-sidecar/clear-user-cache')
+        ->assertOk()
+        ->assertExactJson([
+            'output' => 'User cache cleared successfully.',
+        ]);
+});
+
+it('returns error message when an exception occurs', function () {
+    Cache::shouldReceive('forget')
+        ->once()
+        ->with('sidecar_users')
+        ->andThrow(new Exception('failure'));
+
+    post('__devsquad-sidecar/clear-user-cache')
+        ->assertOk()
+        ->assertExactJson([
+            'output' => 'Error executing command: failure',
+        ]);
+});

--- a/tests/Feature/ClearUserCacheControllerTest.php
+++ b/tests/Feature/ClearUserCacheControllerTest.php
@@ -1,10 +1,9 @@
 <?php
 
 use EliteDevSquad\SidecarLaravel\Http\Middleware\SidecarMiddleware;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
-use function Pest\Laravel\post;
-use function Pest\Laravel\withoutMiddleware;
+
+use function Pest\Laravel\{post, withoutMiddleware};
 
 beforeEach(function () {
     withoutMiddleware(SidecarMiddleware::class);

--- a/tests/Feature/SetSidecarTokenControllerTest.php
+++ b/tests/Feature/SetSidecarTokenControllerTest.php
@@ -49,6 +49,9 @@ it('rejects when token is not a string', function () {
 
 it('queues cookie with correct expiration time', function () {
     Config::set('devsquad-sidecar.auth_token', 'expected');
+    Config::set('devsquad-sidecar.token_duration_in_minutes', 129600); // 3 meses
+
+    $duration = config('devsquad-sidecar.token_duration_in_minutes');
 
     $response = post('__devsquad-sidecar/token', ['token' => 'expected'])
         ->assertOk()
@@ -56,9 +59,15 @@ it('queues cookie with correct expiration time', function () {
 
     $cookie = $response->getCookie('sidecar_token');
 
+    $expectedExpiration = time() + ($duration * 60);
+
     expect($cookie->getName())->toBe('sidecar_token')
         ->and($cookie->getValue())->toBe('expected')
-        ->and($cookie->getExpiresTime())->toBeGreaterThan(time());
+        ->and($cookie->getExpiresTime())->toBeGreaterThan(time())
+        ->and($cookie->getExpiresTime())
+        ->toBeGreaterThanOrEqual($expectedExpiration - 2)
+        ->and($cookie->getExpiresTime())
+        ->toBeLessThanOrEqual($expectedExpiration + 2);
 });
 
 it('returns forbidden when provided token differs from expected', function () {


### PR DESCRIPTION
This pull request introduces improvements to the Sidecar token management and testing, focusing on configurable token expiration, updated documentation, and enhanced test coverage. The most important changes are grouped below by theme.

**Token Expiration Configuration and Usage:**

* Added a new configuration option `token_duration_in_minutes` to `devsquad-sidecar.php`, allowing the Sidecar token expiration time to be set via environment variable, with a default of 90 days (129600 minutes).
* Updated the logic in `SetSidecarTokenController` to use the configurable token duration when queuing the `sidecar_token` cookie, instead of a fixed 7-day expiration.

**Documentation Updates:**

* Updated the `README.md` to reflect the new environment variable `DS_SIDECAR_TOKEN_DURATION_IN_MINUTES` and clarified the format for `DS_SIDECAR_AUTH_TOKEN`.

**Testing Enhancements:**

* Improved the test for token expiration in `SetSidecarTokenControllerTest` to verify that the cookie expiration matches the configured duration precisely.
* Added a new feature test for `ClearUserCacheController` to ensure user cache clearing works as expected and handles exceptions gracefully.

**Dependency Updates:**

* Updated the `laradumps/laradumps` dependency in `composer.json` from version `^4.3` to `^4.5`.