### PR TITLE
fix: remove authentication check from SidecarMiddleware and update tests

### DIFF
--- a/src/Http/Middleware/SidecarMiddleware.php
+++ b/src/Http/Middleware/SidecarMiddleware.php
@@ -4,25 +4,16 @@ namespace EliteDevSquad\SidecarLaravel\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 /** @codeCoverageIgnore */
 class SidecarMiddleware
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        $this->validateAuth();
         $this->validatePermissions($request);
         $this->validateEnabled();
 
         return $next($request);
-    }
-
-    private function validateAuth(): void
-    {
-        if (! Auth::check()) {
-            abort(403, 'Unauthorized. Please log in.');
-        }
     }
 
     private function validatePermissions(Request $request): void

--- a/tests/Feature/SidecarMiddlewareTest.php
+++ b/tests/Feature/SidecarMiddlewareTest.php
@@ -20,12 +20,6 @@ it('allows authenticated users to access non-execute routes without IP restricti
         ->assertOk();
 });
 
-it('blocks unauthenticated users from all routes', function () {
-    postJson('__devsquad-sidecar/execute-command', ['command' => 'view:clear'])
-        ->assertForbidden()
-        ->assertSeeText('Unauthorized. Please log in.');
-});
-
 it('allows authenticated users with matching exact IP to execute commands', function () {
     Config::set('devsquad-sidecar.allowed_ips', ['127.0.0.1']);
 

--- a/tests/Feature/SidecarMiddlewareTest.php
+++ b/tests/Feature/SidecarMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Config;
 
-use function Pest\Laravel\{actingAs, postJson};
+use function Pest\Laravel\{actingAs};
 
 beforeEach(function () {
     Config::set('devsquad-sidecar.enabled', true);

--- a/tests/Feature/SidecarMiddlewareTest.php
+++ b/tests/Feature/SidecarMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Config;
 
-use function Pest\Laravel\{actingAs};
+use function Pest\Laravel\actingAs;
 
 beforeEach(function () {
     Config::set('devsquad-sidecar.enabled', true);


### PR DESCRIPTION
This pull request removes authentication checks from the `SidecarMiddleware`, focusing access control solely on permissions and feature enablement rather than user authentication status. The corresponding test for unauthenticated user blocking is also removed.

**Middleware logic changes:**

* Removed the authentication check (`validateAuth`) from `SidecarMiddleware`, so requests are no longer blocked based on authentication status. (`src/Http/Middleware/SidecarMiddleware.php`)

**Testing updates:**

* Removed the test that verified unauthenticated users are blocked, since authentication is no longer enforced by the middleware. (`tests/Feature/SidecarMiddlewareTest.php`)