### PR TITLE
fix: preserve user-selected time in Set Clock instead of using server time

### DIFF
--- a/src/Http/Controllers/ExecuteFakeClockController.php
+++ b/src/Http/Controllers/ExecuteFakeClockController.php
@@ -16,13 +16,11 @@ class ExecuteFakeClockController
         $datetimeInput = $request->date('datetime');
 
         if ($datetimeInput) {
-            $datetime = $datetimeInput->setTimeFromTimeString(now()->toTimeString());
+            Carbon::setTestNow($datetimeInput);
 
-            Carbon::setTestNow($datetime);
+            session(['sidecar_fake_clock' => $datetimeInput->toDateTimeString()]);
 
-            session(['sidecar_fake_clock' => $datetime->toDateTimeString()]);
-
-            return response()->json(['output' => 'Fake clock set to '.$datetime->toDateTimeString()]);
+            return response()->json(['output' => 'Fake clock set to '.$datetimeInput->toDateTimeString()]);
         }
 
         Carbon::setTestNow();

--- a/src/Sidecar.php
+++ b/src/Sidecar.php
@@ -2,9 +2,11 @@
 
 namespace EliteDevSquad\SidecarLaravel;
 
+use App\Models\User;
+
 class Sidecar
 {
-    public static string $userModel = \App\Models\User::class; // @phpstan-ignore-line
+    public static string $userModel = User::class; // @phpstan-ignore-line
 
     public static mixed $userBuilder = null;
 

--- a/tests/Feature/ExecuteFakeClockControllerTest.php
+++ b/tests/Feature/ExecuteFakeClockControllerTest.php
@@ -19,8 +19,7 @@ it('sets fake clock when datetime is provided', function () {
         'datetime' => $fakeDate,
     ])->assertOk();
 
-    $expected = Carbon::parse($fakeDate)
-        ->setTimeFromTimeString(now()->toTimeString());
+    $expected = Carbon::parse($fakeDate);
 
     $response->assertJson([
         'output' => 'Fake clock set to '.$expected->toDateTimeString(),

--- a/tests/Feature/ExecuteTinkerOnQueueTest.php
+++ b/tests/Feature/ExecuteTinkerOnQueueTest.php
@@ -27,7 +27,7 @@ describe('Sidecar Tinker Execution', function () {
     it('executes tinker code and logs the output', function () {
         $code = '1 + 1';
 
-        $kernel = \Mockery::mock(Kernel::class)
+        $kernel = Mockery::mock(Kernel::class)
             ->shouldReceive('call')
             ->once()
             ->with('tinker', ['--execute' => $code])
@@ -46,7 +46,7 @@ describe('Sidecar Tinker Execution', function () {
 
         Log::shouldReceive('info')
             ->zeroOrMoreTimes()
-            ->with('Sidecar Tinker executed', \Mockery::on(fn ($context) => is_array($context)
+            ->with('Sidecar Tinker executed', Mockery::on(fn ($context) => is_array($context)
                 && ($context['code'] ?? null) === '1 + 1'
                 && ($context['output'] ?? null) === '2'
                 && array_key_exists('batchId', $context)
@@ -58,9 +58,9 @@ describe('Sidecar Tinker Execution', function () {
 
     it('reports exceptions when tinker execution fails', function () {
         $code = '1 + 1';
-        $exception = new \RuntimeException('tinker failed');
+        $exception = new RuntimeException('tinker failed');
 
-        $kernel = \Mockery::mock(Kernel::class)
+        $kernel = Mockery::mock(Kernel::class)
             ->shouldReceive('call')
             ->once()
             ->with('tinker', ['--execute' => $code])
@@ -70,7 +70,7 @@ describe('Sidecar Tinker Execution', function () {
         app()->instance(Kernel::class, $kernel);
         Artisan::swap($kernel);
 
-        $handler = \Mockery::mock(ExceptionHandler::class);
+        $handler = Mockery::mock(ExceptionHandler::class);
         $handler->shouldReceive('report')->once()->with($exception);
         $handler->shouldReceive('render')->andReturnNull();
         app()->instance(ExceptionHandler::class, $handler);

--- a/tests/Feature/SidecarMiddlewareTest.php
+++ b/tests/Feature/SidecarMiddlewareTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Illuminate\Support\Facades\Config;
+use Tests\User;
 
 use function Pest\Laravel\actingAs;
 
 beforeEach(function () {
     Config::set('devsquad-sidecar.enabled', true);
-    $this->user = \Tests\User::create([
+    $this->user = User::create([
         'name' => 'Test User',
         'email' => 'test@example.com',
     ]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,4 +1,6 @@
 <?php
 
-pest()->extend(Tests\TestCase::class)
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
     ->in('Feature');


### PR DESCRIPTION
### Summary

Fixed the Set Clock feature to preserve the exact time selected by the user in the datepicker, instead of overwriting it with the server's current time.

### Problem

When a user selected a specific date and time in the datepicker (e.g., 2025-08-25 15:30), the backend was overwriting the selected time with the server's current time (e.g., 10:45), making it impossible to set a fake clock to a specific time.

### Root Cause

The ExecuteFakeClockController contained this line:

$datetime = $datetimeInput->setTimeFromTimeString(now()->toTimeString());
This intentionally replaced the user's selected time with now().

### Solution

Removed the time override logic and now use the datetime input directly:

Carbon::setTestNow($datetimeInput);
Changes

- ExecuteFakeClockController.php - Use datetime input directly instead of overwriting time
- ExecuteFakeClockControllerTest.php - Updated test to expect the correct behavior