### PR TITLE
Fix without_users parameter not filtering users from response

### DIFF
--- a/src/Http/Controllers/GetSidecarDataController.php
+++ b/src/Http/Controllers/GetSidecarDataController.php
@@ -17,7 +17,7 @@ class GetSidecarDataController
             abort(403, 'Sidecar is disabled.');
         }
 
-        $initialRequest = $request->get('without_users') ?? 'false';
+        $withoutUsers = $request->boolean('without_users');
 
         /** @var string $defaultConnection */
         $defaultConnection = config('database.default', '');
@@ -31,7 +31,7 @@ class GetSidecarDataController
         /** @var string $projectName */
         $projectName = config('app.name', '');
 
-        $users = $this->getUsers();
+        $users = $withoutUsers ? [] : $this->getUsers();
 
         return response()->json([
             'enabled' => true,

--- a/tests/Feature/GetSidecarDataControllerTest.php
+++ b/tests/Feature/GetSidecarDataControllerTest.php
@@ -145,3 +145,43 @@ it('aborts when sidecar is disabled', function () {
     getJson('__devsquad-sidecar/data')
         ->assertForbidden();
 });
+
+it('returns empty users array when without_users is true', function () {
+    $this->sidecar->shouldReceive('getUserMap')->andReturn([
+        'id' => 'id',
+        'name' => 'name',
+        'email' => 'email',
+        'role' => 'admin',
+    ]);
+    $this->sidecar->shouldNotReceive('getUserQueryBuilder');
+
+    Config::set('devsquad-sidecar.enabled', true);
+
+    withoutMiddleware(SidecarMiddleware::class);
+
+    $response = getJson('__devsquad-sidecar/data?without_users=true')
+        ->assertOk();
+
+    $response->assertJson([
+        'users' => [],
+    ]);
+});
+
+it('returns users when without_users is false', function () {
+    $this->sidecar->shouldReceive('getUserMap')->andReturn([
+        'id' => 'id',
+        'name' => 'name',
+        'email' => 'email',
+        'role' => 'admin',
+    ]);
+    $this->sidecar->shouldReceive('getUserQueryBuilder')->andReturn(User::query());
+
+    Config::set('devsquad-sidecar.enabled', true);
+
+    withoutMiddleware(SidecarMiddleware::class);
+
+    $response = getJson('__devsquad-sidecar/data?without_users=false')
+        ->assertOk();
+
+    $response->assertJsonCount(2, 'users');
+});


### PR DESCRIPTION
### Summary

Fixed without_users query parameter being ignored in GetSidecarDataController
The parameter was retrieved but never used to conditionally filter users from the response
Changes

Replaced unused $initialRequest variable with $withoutUsers = $request->boolean('without_users')

Added conditional logic to return empty array when without_users=true
Added tests for both without_users=true and without_users=false scenarios